### PR TITLE
Prepare for `0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-nuget"
-version = "0.0.3"
+version = "0.1.0"
 dependencies = [
  "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (git+https://github.com/rust-lang-nursery/log.git)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term-painter 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,11 +61,6 @@ dependencies = [
 [[package]]
 name = "cc"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -123,10 +118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "log"
 version = "0.3.8"
-source = "git+https://github.com/rust-lang-nursery/log.git#b8d931bf887e25a1bfc7c484de61ad14dbd10b56"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "miniz-sys"
@@ -334,14 +326,13 @@ dependencies = [
 "checksum bzip2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3eafc42c44e0d827de6b1c131175098fe7fb53b8ce8a47e65cb3ea94688be24"
 "checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
 "checksum clap 2.21.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd79299b14c6e7c1cc304dafb688c0c30df267c4615a3d3a97ea4625925ccdfb"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
-"checksum log 0.3.8 (git+https://github.com/rust-lang-nursery/log.git)" = "<none>"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-nuget"
-version = "0.0.3"
+version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 description = "Bundle Rust libraries as Nuget packages"
 repository = "https://github.com/KodrAus/nuget-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ xml-rs = "~0.3"
 zip = "~0.2"
 chrono = "~0.3"
 semver = "~0.6"
-log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["std"] }
-lazy_static = "*"
+log = "~0.3"
+lazy_static = "~0.2"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,14 +1,14 @@
 use std::io::{stderr, Write};
-use log::{self, Level, LevelFilter, Log, Metadata, Record};
+use log::{self, LogLevel, LogLevelFilter, Log, LogMetadata, LogRecord};
 use term_painter::ToStyle;
 use term_painter::Color::*;
 
 struct Logger;
 
 impl Log for Logger {
-    fn log(&self, record: &Record) {
+    fn log(&self, record: &LogRecord) {
         match record.level() {
-            Level::Error => {
+            LogLevel::Error => {
                 let _ = writeln!(
                     stderr(),
                     "{}{}",
@@ -16,14 +16,14 @@ impl Log for Logger {
                     Red.paint(record.args())
                 );
             }
-            Level::Warn => {
+            LogLevel::Warn => {
                 println!(
                     "{}{}",
                     Yellow.bold().paint("warn: "),
                     Yellow.paint(record.args())
                 );
             }
-            Level::Debug => {
+            LogLevel::Debug => {
                 println!(
                     "{}{}",
                     Blue.bold().paint("debug: "),
@@ -34,16 +34,14 @@ impl Log for Logger {
         }
     }
 
-    fn enabled(&self, _: &Metadata) -> bool {
+    fn enabled(&self, _: &LogMetadata) -> bool {
         true
     }
-
-    fn flush(&self) {}
 }
 
 pub fn init() {
-    log::set_boxed_logger(|max_level| {
-        max_level.set(LevelFilter::Debug);
+    log::set_logger(|max_level| {
+        max_level.set(LogLevelFilter::Debug);
         Box::new(Logger)
     }).unwrap();
 }


### PR DESCRIPTION
Making sure everything is ready for an `0.1.0` release with basic cross-platform build support. I would eventually like to run this in CI too, but that doesn't need to block a release.